### PR TITLE
Feature Request: Add request attribute as an alternative for parameter injection with the templating module

### DIFF
--- a/content/templates.xql
+++ b/content/templates.xql
@@ -256,7 +256,7 @@ declare %private function templates:map-argument($arg as element(argument), $par
             templates:cast($param, $type)
         } catch * {
             error($templates:TYPE_ERROR, "Failed to cast parameter value '" || $param || "' to the required target type for " ||
-                "template function parameter $" || $name || " of function " || ($arg/../@name) || ". Required type was: " ||
+                "template function parameter $" || $var || " of function " || ($arg/../@name) || ". Required type was: " ||
                 $type || ". " || $err:description)
         }
     return


### PR DESCRIPTION
Currently, only request parameters and session attributes are injected as function parameters while request attributes (as beeing set by controller actions with `set-attribute`) are not taken into account.
Commit 9b1315695a01da4888eb8401b41dd685158fe1a2 contains the actual proposal while 688757da6d8d2bab68a7c92b9d24824635ad6278 and 534cc2c4d922d6981278dcea92662fd0fbe3fa6a are small bug fixes. I do wonder though, why the declaration of `$templates:TYPE_ERROR` was missing (for several months) since the code breaks without it?!
