### PR TITLE
allow lookup params to have access to model

### DIFF
--- a/content/templates.xql
+++ b/content/templates.xql
@@ -282,7 +282,7 @@ declare %private function templates:process-output($node as element(), $model as
             $output
 };
 
-declare %private function templates:map-arguments($inspect as element(function), $parameters as map(xs:string, xs:string), $param-lookup as function(xs:string) as item()*, $model as map(*)) {
+declare %private function templates:map-arguments($inspect as element(function), $parameters as map(xs:string, xs:string), $param-lookup as function(xs:string, map()) as item()*, $model as map(*)) {
     let $args := $inspect/argument
     return
         if (count($args) > 2) then
@@ -293,7 +293,7 @@ declare %private function templates:map-arguments($inspect as element(function),
             ()
 };
 
-declare %private function templates:map-argument($arg as element(argument), $parameters as map(xs:string, xs:string), $param-lookup as function(xs:string) as item()*, $model as map(*)) 
+declare %private function templates:map-argument($arg as element(argument), $parameters as map(xs:string, xs:string), $param-lookup as function(xs:string, map()) as item()*, $model as map(*)) 
     as function() as item()* {
     let $var := $arg/@var
     let $type := $arg/@type/string()


### PR DESCRIPTION
Motivation : I'd like to be able to have access to `$model` when providing my own lookup for getting parameter values. Something like: 

``` xquery
declare  function my:lookup-param($var as xs:string, $model as map(*)) as item()* {
    my:first-result((
        (:------------------------:)
       function() { if(map:contains($model,$templates:CONFIG_PARAM_MAP)) then model($templates:CONFIG_PARAM_MAP)($var) else ()},
        (:------------------------:)
        function() { request:get-parameter($var, ()) },
        function() { session:get-attribute($var) },
        function() { request:get-attribute($var) }
    ))
};
```

~~One problem with this pull request is that it changes the arity of the lookup-param function (from just `($var)` to `($var,$model)`). That might break apps already providing their own lookup function for templates...~~

With the last commit (making use of partial functions) lookup-functions are called as previously. 
