### PR TITLE
Prepare 0.4.1 release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ resources/scripts/ace
 build
 expath-pkg.xml
 emmet.js
+local.build.properties

--- a/build.properties
+++ b/build.properties
@@ -1,0 +1,7 @@
+#
+# Don't directly modify this file. Instead, copy it to local.build.properties and
+# edit that.
+#
+
+project.name=shared-resources
+project.version=0.4.1

--- a/build.xml
+++ b/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project basedir="." default="all" name="shared-resources">
-    <property name="project.app" value="shared-resources"/>
-    <property name="project.version" value="0.4.0"/>
+    <property file="local.build.properties"/>
+    <property file="build.properties"/>
     <property name="tools" value="./tools"/>
     <property name="build" value="./build"/>
     <property name="scripts" value="./resources/scripts"/>
@@ -13,7 +13,7 @@
         <isset property="git.commit"/>
     </condition>
     <target name="all" depends="ace,xar"/>
-    <target     name="rebuild" depends="clean,all"/>
+    <target name="rebuild" depends="clean,all"/>
     <target name="prepare-ace">
         <get src="${emmet.url}" dest="${scripts}/emmet.js"/>
     </target>
@@ -36,10 +36,11 @@
         <mkdir dir="${build}"/>
         <copy file="expath-pkg.xml.tmpl" tofile="expath-pkg.xml" filtering="true" overwrite="true">
             <filterset>
+                <filter token="project.name" value="${project.name}"/>
                 <filter token="project.version" value="${project.version}"/>
             </filterset>
         </copy>
-        <zip destfile="${build}/${project.app}-${project.version}${git.commit}.xar">
+        <zip destfile="${build}/${project.name}-${project.version}${git.commit}.xar">
             <fileset dir=".">
                 <include name="*.*"/>
                 <include name="resources/**"/>
@@ -54,7 +55,7 @@
         <input message="Enter password:" addproperty="server.pass" defaultvalue="">
             <handler type="secure"/>
         </input>
-        <property name="xar" value="${project.app}-${project.version}${git.commit}.xar"/>
+        <property name="xar" value="${project.name}-${project.version}${git.commit}.xar"/>
         <exec executable="curl">
             <arg line="-T ${build}/${xar} -u admin:${server.pass} ${server.url}/${xar}"/>
         </exec>

--- a/expath-pkg.xml.tmpl
+++ b/expath-pkg.xml.tmpl
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<package xmlns="http://expath.org/ns/pkg" name="http://exist-db.org/apps/shared" abbrev="shared" version="@project.version@" spec="1.0">
+<package xmlns="http://expath.org/ns/pkg" name="http://exist-db.org/apps/shared" abbrev="@project.name@" version="@project.version@" spec="1.0">
     <title>Shared Resources: jquery, dojo, ace ...</title>
-    <!-- fixme! This test needs to change.  -->
-    <dependency processor="eXist-db" version="trunk &gt; rev 18070"/>
     <xquery>
         <namespace>http://exist-db.org/xquery/apps</namespace>
         <file>apputil.xql</file>

--- a/repo.xml
+++ b/repo.xml
@@ -2,7 +2,7 @@
 <repo:meta xmlns="http://exist-db.org/xquery/repo" xmlns:repo="http://exist-db.org/xquery/repo">
     <repo:description>Shared resources used by other apps</repo:description>
     <repo:author>Wolfgang Meier</repo:author>
-    <repo:website/>
+    <repo:website>https://github.com/eXist-db/shared-resources</repo:website>
     <repo:status>alpha</repo:status>
     <repo:license>GNU-LGPL</repo:license>
     <repo:copyright>true</repo:copyright>
@@ -13,7 +13,7 @@
     <repo:permissions user="admin" password="" group="dba" mode="0775"/>
     <changelog>
         <change version="0.3.5">
-            <ul xmlns="">
+            <ul xmlns="http://www.w3.org/1999/xhtml">
                 <li>Move site-wide CSS to shared-resources. Modularize design using less.</li>
                 <li>Added bootstrap</li>
                 <li>Bug fixes and minor improvements in templating</li>
@@ -21,21 +21,39 @@
             </ul>
         </change>
         <change version="0.3.6">
-            <ul xmlns="">
+            <ul xmlns="http://www.w3.org/1999/xhtml">
                 <li>Small syntax error in templates.xql</li>
             </ul>
         </change>
         <change version="0.3.7">
-            <ul xmlns="">
+            <ul xmlns="http://www.w3.org/1999/xhtml">
                 <li>Externalised parameter value resolution in templating. Now useable outside XQuery URL Rewrite context.</li>
                 <li>Updated ace</li>
             </ul>
         </change>
         <change version="0.3.8">
-            <ul xmlns="">
+            <ul xmlns="http://www.w3.org/1999/xhtml">
                 <li>Fixed permission checks in dbutil module: functions should not fail if user lacks the permission to browse into a collection.</li>
                 <li>Updated ace</li>
                 <li>Fixed templates:surround to report a proper error if a template could not be found.</li>
+            </ul>
+        </change>
+        <change version="0.3.9">
+            <ul xmlns="http://www.w3.org/1999/xhtml">
+                <li>No release notes prepared for this version.</li>
+            </ul>
+        </change>
+        <change version="0.4.0">
+            <ul xmlns="http://www.w3.org/1999/xhtml">
+                <li>No release notes prepared for this version.</li>
+            </ul>
+        </change>
+        <change version="0.4.1">
+            <ul xmlns="http://www.w3.org/1999/xhtml">
+                <li>Fixed templates:each to not output empty element.</li>
+                <li>Improved HTML output by stripping data-template attributes unless configuration option "debug" is set to true.</li>
+                <li>Aligned limit of template:resolve to the max arity number in templates:call-with-args.</li>
+                <li>Fixed for erroneous return type from two functions in apputil module affecting package installation.</li>
             </ul>
         </change>
     </changelog>


### PR DESCRIPTION
As proposed in #19:
- performed a diff against previous release in public-repo to ensure all work was in source (confirmed; no action necessary)
- adopt build.properties convention of other core apps
- add link to repo as repo website
- add release notes