### PR TITLE
Preserve #poweredby logo aspect ratio

### DIFF
--- a/resources/css/exist-2.2.css
+++ b/resources/css/exist-2.2.css
@@ -246,7 +246,7 @@ body {
 #poweredby {
   float: right;
   width: 120px;
-  height: 50px;
+  height: 56px;
   margin-bottom: 10px;
   display: inline-block;
   background: url(../images/powered-by.svg) no-repeat 50%;


### PR DESCRIPTION
Current logo is '`width="300" height="140"`', so:
````
#poweredby {
  width: 120px;
  height: 56px;
}
````
preserves its aspect ratio.