### PR TITLE
Prevent infinite loop in function lookup

### DIFF
--- a/content/templates.xql
+++ b/content/templates.xql
@@ -5,7 +5,8 @@ xquery version "3.1";
  : 
  : @version 2.1
  : @author Wolfgang Meier
- : @contributor Adam retter
+ : @contributor Adam Retter
+ : @contributor Joe Wicentowski
 :)
 module namespace templates="http://exist-db.org/xquery/templates";
 
@@ -30,6 +31,7 @@ declare variable $templates:NOT_FOUND := QName("http://exist-db.org/xquery/templ
 declare variable $templates:TOO_MANY_ARGS := QName("http://exist-db.org/xquery/templates", "TooManyArguments");
 declare variable $templates:PROCESSING_ERROR := QName("http://exist-db.org/xquery/templates", "ProcessingError");
 declare variable $templates:TYPE_ERROR := QName("http://exist-db.org/xquery/templates", "TypeError");
+declare variable $templates:MAX_ARITY := 20;
 
 declare variable $templates:ATTR_DATA_TEMPLATE := "data-template";
 
@@ -294,6 +296,8 @@ declare %private function templates:resolve($arity as xs:int, $func as xs:string
     return
         if (exists($fn)) then
             $fn
+        else if ($arity ge $templates:MAX_ARITY) then
+            ()
         else
             templates:resolve($arity + 1, $func, $resolver)
 };

--- a/content/templates.xql
+++ b/content/templates.xql
@@ -189,7 +189,11 @@ declare %private function templates:call($classOrAttr as item(), $node as elemen
         if (exists($call)) then
             templates:call-by-introspection($node, $parameters, $model, $call)
         else if ($model($templates:CONFIGURATION)($templates:CONFIG_STOP_ON_ERROR)) then
-            error($templates:NOT_FOUND, "No template function found for call " || $func)
+            error($templates:NOT_FOUND, 
+                "No template function found for call " || $func || 
+                " (Max arity of " || $templates:MAX_ARITY ||
+                " has been exceeded in searching for this template function." ||
+                "If needed, adjust $templates:MAX_ARITY in the templates.xql module.)")
         else
             (: Templating function not found: just copy the element :)
             element { node-name($node) } {


### PR DESCRIPTION
# The problem

https://github.com/eXist-db/shared-resources/pull/29 (released in https://github.com/eXist-db/shared-resources/releases/tag/v0.5.0) added the following feature:

> Template functions can now accept an arbitrary number of parameters, previously limited to 15 

... but this enhancement introduced a bug, reported in https://github.com/eXist-db/shared-resources/issues/33: If a template references a non-existent function, the request for this template hangs indefinitely, and the query has to be manually killed. 

# Diagnosis

The problem was caused by an infinite loop in `templates:resolve()`, which looks up a function named in a template call. It checks to see if a function of the given name and arity 2 exists (this would correspond to a basic templating function that contains 2 parameters, `$node` and `$model`); if no function at this arity is found, the check is performed again, incrementing the arity by 1, and again recursively—with *no bound*. 

This recursive check for arity is needed, since the function called may take fewer or greater than the number of parameters supplied in the template; the templating module allows parameters to come from at least 3 other locations (URL parameters, request attributes, and session attributes), with an extension mechanism for developers to supply their own ordered set of parameter sources. So the templating module has no way to know in advance the arity to apply. Instead, it needs to find a function whose arity matches. It proceeds from least to greatest arity. But there's currently no upper bound, meaning that missing functions lead to an infinite loop.

# Solutions

One solution would be to enforce an upper bound for arity in the `$lookup` (or `$resolve`) function they supply to `templates:apply()` in their apps' `modules/view.xql` query:

```xquery
let $lookup := function ($functionName as xs:string, $arity as xs:int) {
    if ($arity le 20) then 
        try {
            function-lookup(xs:QName($functionName), $arity)
        } catch * {
            ()
        }
    else
        ()
}
```

However, that would require changes in apps that previously worked before #29, and it would impose a burden on all apps that wanted to insulate themselves from this problem.

The approach taken in this PR is to move the maximum arity value into the templating function, hard-coding the previous limit of 20 for templating function arity. This limit was adequate before #29 and could always be adjusted upward if needed in a future PR.

# Result

Now, if a non-existent function is referenced, the templating module immediately returns an error:

> An error has occurred
> An error has been generated by the application.
> 
> templates:NotFound No template function found for call app:doh-a-non-existent-function [at line 191, column 85, source: /db/apps/shared-resources/content/templates.xql]
> In function:
>	templates:call(item(), element(), map(*)) [137:36:/db/apps/shared-resources/content/templates.xql]

Closes https://github.com/eXist-db/shared-resources/issues/33.

