### PR TITLE
Fix calls to deprecated functions

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -7,16 +7,12 @@
     <property name="ace" value="${scripts}/ace"/>
     <property name="ace.src" value="./support/ace"/>
     <property name="server.url" value="http://demo.exist-db.org/exist/apps/public-repo/public/"/>
-    <property name="emmet.url" value="https://nightwing.github.io/emmet-core/emmet.js"/>
     <condition property="git.commit" value="${git.commit}" else="">
         <isset property="git.commit"/>
     </condition>
     <target name="all" depends="ace,xar"/>
     <target name="rebuild" depends="clean,all"/>
-    <target name="prepare-ace">
-        <get src="${emmet.url}" dest="${scripts}/emmet.js"/>
-    </target>
-    <target name="ace" depends="prepare-ace">
+    <target name="ace">
         <mkdir dir="${ace}"/>
         <mkdir dir="${ace.src}/build/src-min"/>
         <mkdir dir="${ace.src}/build/kitchen-sink"/>
@@ -30,7 +26,6 @@
     </target>
     <target name="clean">
         <delete dir="${ace}"/>
-        <delete file="${scripts}/emmet.js"/>
         <delete dir="${build}"/>
         <delete file="expath-pkg.xml"/>
     </target>

--- a/content/apputil.xql
+++ b/content/apputil.xql
@@ -28,7 +28,7 @@ declare variable $apputil:DEPENDENCY := xs:QName("apputil:DEPENDENCY");
  : when displaying a page.
  :)
 declare variable $apputil:PACKAGES :=
-    map:new(
+    map:merge(
         for $app in collection(repo:get-root())//expath:package
         return
             map:entry($app/@abbrev/string(), util:collection-name($app))


### PR DESCRIPTION
Fix calls to deprecated functions so code works again in eXist 5.0/develop.

Also removes the download for emmet.js. This doesn't work anymore and will also be disabled in eXide.