### PR TITLE
improve templates:form-control

### DIFF
--- a/content/templates.xql
+++ b/content/templates.xql
@@ -596,6 +596,13 @@ declare function templates:form-control($node as node(), $model as map(*)) as no
     let $control := local-name($node)
     return
         switch ($control)
+        case "form" return
+            element { node-name($node) }{
+                $node/@* except $node/@action,
+                attribute action { request:get-parameter('origin', '') },
+                for $n in $node/node()
+                return templates:form-control($n, $model)
+            }
         case "input" return
             let $type := $node/@type
             let $name := $node/@name

--- a/content/templates.xql
+++ b/content/templates.xql
@@ -599,7 +599,7 @@ declare function templates:form-control($node as node(), $model as map(*)) as no
         case "form" return
             element { node-name($node) }{
                 $node/@* except $node/@action,
-                attribute action { request:get-parameter('origin', '') },
+                attribute action { templates:get-configuration($model, "templates:form-control")($templates:CONFIG_PARAM_RESOLVER)("origin") },
                 for $n in $node/node()
                 return templates:form-control($n, $model)
             }

--- a/content/templates.xql
+++ b/content/templates.xql
@@ -599,7 +599,7 @@ declare function templates:form-control($node as node(), $model as map(*)) as no
         case "form" return
             element { node-name($node) }{
                 $node/@* except $node/@action,
-                attribute action { templates:get-configuration($model, "templates:form-control")($templates:CONFIG_PARAM_RESOLVER)("origin") },
+                attribute action { templates:get-configuration($model, "templates:form-control")($templates:CONFIG_PARAM_RESOLVER)("form-action") },
                 for $n in $node/node()
                 return templates:form-control($n, $model)
             }


### PR DESCRIPTION
adds a switch case for the xhtml:form element itself for externally supplying the `form/@action` via templating.